### PR TITLE
fix compilation issues.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,4 @@
+project(libmajesty)
 cmake_minimum_required(VERSION 2.8)
 
 include(${CMAKE_ROOT}/Modules/ExternalProject.cmake)
@@ -9,7 +10,7 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -DLIN64")
 
 externalproject_add(
 	abc-project
-	HG_REPOSITORY "https://bitbucket.org/alanmi/abc"
+	GIT_REPOSITORY "https://github.com/berkeley-abc/abc.git"
 	PREFIX "abc"
 	CONFIGURE_COMMAND ""
 	UPDATE_COMMAND ""

--- a/include/exact.h
+++ b/include/exact.h
@@ -998,7 +998,7 @@ namespace majesty {
 	}
 
 	// We only want gates to implement functions from the specified set of restricted functions
-	void add_gate_restrictions(synth_spec* spec, const std::vector<cirkit::tt>& restricted_functions) {
+	inline void add_gate_restrictions(synth_spec* spec, const std::vector<cirkit::tt>& restricted_functions) {
 		assert(restricted_functions.size() > 0);
 		const auto num_vars = tt_num_vars(restricted_functions[0]);
 		const auto num_funcs = (1u << (1u << num_vars)) / 2; // Divide by 2 since we only consider normal functions

--- a/include/logic_rewriting.h
+++ b/include/logic_rewriting.h
@@ -36,7 +36,7 @@ namespace majesty {
 	boost::optional<xmg> xmg_from_luts(const xmg&, const cover&, const bestmap&, const funcmap&, std::vector<cirkit::tt>&, unsigned);
 	boost::optional<xmg> xmg_from_luts(const xmg&, const cover&, const bestmap&, const funcmap&, std::vector<cirkit::tt>&, unsigned, timeout_behavior);
 
-	logic_ntk abc_heuristic_logic_ntk(const cirkit::tt& func) {
+	inline logic_ntk abc_heuristic_logic_ntk(const cirkit::tt& func) {
 		auto optcmd = (boost::format("abc -c \"read_truth %s; strash; resyn2; write_verilog tmp.v\"") % cirkit::tt_to_hex(func)).str();
 		auto success = system(optcmd.c_str());
 		if (success != 0) {
@@ -58,7 +58,7 @@ namespace majesty {
 	}
 
 	std::pair<nodeid, bool> 
-		parse_into_logic_ntk(logic_ntk& ntk, const logic_ntk& opt_ntk, 
+	inline parse_into_logic_ntk(logic_ntk& ntk, const logic_ntk& opt_ntk, 
 				const input_map_t& imap, bool invert_output) {
 		const auto& opt_nodes = opt_ntk.nodes();
 		std::vector<std::pair<nodeid,bool>> nids(opt_nodes.size());
@@ -301,7 +301,7 @@ namespace majesty {
 		return cntk;
 	}
 
-	int recursive_deselect(const nodeid nid, const std::vector<ln_node>& nodes, std::unordered_map<nodeid,unsigned>& nref) {
+       inline int recursive_deselect(const nodeid nid, const std::vector<ln_node>& nodes, std::unordered_map<nodeid,unsigned>& nref) {
 		const auto& node = nodes[nid];
 		if (node.pi) {
 			return 0;
@@ -316,7 +316,7 @@ namespace majesty {
 		return area;
 	}
 
-	int recursive_select(const nodeid nid, const std::vector<ln_node>& nodes, std::unordered_map<nodeid,unsigned>& nref) {
+	inline int recursive_select(const nodeid nid, const std::vector<ln_node>& nodes, std::unordered_map<nodeid,unsigned>& nref) {
 		const auto& node = nodes[nid];
 		if (node.pi) {
 			return 0;
@@ -332,7 +332,7 @@ namespace majesty {
 		return area;
 	}
 
-	int virtual_recursive_deselect(const logic_ntk& ntk, const logic_ntk& opt_ntk, 
+	inline int virtual_recursive_deselect(const logic_ntk& ntk, const logic_ntk& opt_ntk, 
 			const std::vector<nodeid>& fanin, const std::unordered_map<nodeid, nodeid>& nodemap, 
 			std::unordered_map<nodeid, unsigned>& nref) {
 		auto area = 0;
@@ -355,7 +355,7 @@ namespace majesty {
 		return area;
 	}
 
-	int virtual_recursive_select(const logic_ntk& ntk, const logic_ntk& opt_ntk, 
+	inline int virtual_recursive_select(const logic_ntk& ntk, const logic_ntk& opt_ntk, 
 			const std::vector<nodeid>& fanin, const std::unordered_map<nodeid,nodeid>& nodemap, 
 			std::unordered_map<nodeid,unsigned>& nref) {
 		auto area = 0;


### PR DESCRIPTION
The changes in this PR allow `libmajesty` to be compiled on recent platforms.

Summary of changes:
- ABC has been moved from bitbucket to github, such that the path needs to be adapted in the build files.
- Several functions defined in the headers `exact.h` and `logic_rewriting.h` need to be inlined to avoid duplicate symbol errors when linking the project.
- The CMake project has been assigned the name `libmajesty` to silence warnings from recent CMake versions. 